### PR TITLE
gm-tools 1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 [![gm-tools](http://i.imgur.com/LzmaKvH.png)](#)
 
-# gm-tools [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/gm-tools.svg)](https://www.npmjs.com/package/gm-tools) [![Downloads](https://img.shields.io/npm/dt/gm-tools.svg)](https://www.npmjs.com/package/gm-tools) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# gm-tools
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/gm-tools.svg)](https://www.npmjs.com/package/gm-tools) [![Downloads](https://img.shields.io/npm/dt/gm-tools.svg)](https://www.npmjs.com/package/gm-tools) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Friendly tools for interacting with GraphicsMagick.
 
@@ -119,11 +121,6 @@ Friendly tools for interacting with graphicsmagick
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
-## :dizzy: Where is this library used?
-If you are using this library in one of your projects, add it in this list. :sparkles:
-
-
- - [`image-parser`](https://github.com/IonicaBizau/image-parser#readme)—An image parser that works.
 
 ## :scroll: License
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "graphicsmagick"
   ],
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -43,6 +43,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
